### PR TITLE
Resolve Address Comparison Problem

### DIFF
--- a/lib/failed_autoredeems.ts
+++ b/lib/failed_autoredeems.ts
@@ -120,7 +120,10 @@ const isMatchingSender = async (
     const rec = await getL1TXRec(deposit.transactionHash)
     const depositSenderFromRec = rec.from.toLowerCase()
 
-    if (depositSenderFromGraph == (process.env.SENDER_ADDRESS!).toLowerCase() || depositSenderFromRec == (process.env.SENDER_ADDRESS!).toLowerCase()) {
+    if (
+      depositSenderFromGraph == process.env.SENDER_ADDRESS!.toLowerCase() ||
+      depositSenderFromRec == process.env.SENDER_ADDRESS!.toLowerCase()
+    ) {
       return true
     }
   }
@@ -129,7 +132,10 @@ const isMatchingSender = async (
     const retryableSenderFromGraph = l1Report.sender.toLowerCase()
     const rec = await getL1TXRec(l1Report.transactionHash)
     const retryableSenderFromRec = rec.from.toLowerCase()
-    if (retryableSenderFromGraph === (process.env.SENDER_ADDRESS!).toLowerCase() || retryableSenderFromRec === (process.env.SENDER_ADDRESS!).toLowerCase()) {
+    if (
+      retryableSenderFromGraph === process.env.SENDER_ADDRESS!.toLowerCase() ||
+      retryableSenderFromRec === process.env.SENDER_ADDRESS!.toLowerCase()
+    ) {
       return true
     }
   }
@@ -227,7 +233,9 @@ const getFailedTickets = async () => {
     l2SubgraphEndpoint,
     FAILED_AUTOREDEEM_RETRYABLES_QUERY,
     {
-      fromTimestamp: getPastTimestamp(parseInt(process.env.CREATED_SINCE_DAYS_AGO!)),
+      fromTimestamp: getPastTimestamp(
+        parseInt(process.env.CREATED_SINCE_DAYS_AGO!)
+      ),
     }
   )) as FailedRetryableRes
   const failedTickets: L2TicketReport[] = queryResult['retryables']
@@ -257,5 +265,3 @@ export const checkFailedRetryablesLoop = async () => {
   setChainParams()
   await checkFailedRetryables()
 }
-
-

--- a/lib/failed_autoredeems.ts
+++ b/lib/failed_autoredeems.ts
@@ -116,30 +116,21 @@ const isMatchingSender = async (
   l1Report: L1TicketReport | undefined
 ): Promise<boolean> => {
   if (deposit !== undefined) {
-    const depositSenderFromGraph = deposit.sender
+    const depositSenderFromGraph = deposit.sender.toLowerCase()
     const rec = await getL1TXRec(deposit.transactionHash)
-    const depositSenderFromRec = rec.from
-    if (depositSenderFromGraph === process.env.SENDER_ADDRESS) {
+    const depositSenderFromRec = rec.from.toLowerCase()
+
+    if (depositSenderFromGraph == (process.env.SENDER_ADDRESS!).toLowerCase() || depositSenderFromRec == (process.env.SENDER_ADDRESS!).toLowerCase()) {
       return true
-    }
-    if (depositSenderFromRec === process.env.SENDER_ADDRESS) {
-      return true
-    } else {
-      return false
     }
   }
 
   if (l1Report !== undefined) {
-    const retryableSenderFromGraph = l1Report.sender
+    const retryableSenderFromGraph = l1Report.sender.toLowerCase()
     const rec = await getL1TXRec(l1Report.transactionHash)
-    const retryableSenderFromRec = rec.from
-    if (retryableSenderFromGraph === process.env.SENDER_ADDRESS) {
+    const retryableSenderFromRec = rec.from.toLowerCase()
+    if (retryableSenderFromGraph === (process.env.SENDER_ADDRESS!).toLowerCase() || retryableSenderFromRec === (process.env.SENDER_ADDRESS!).toLowerCase()) {
       return true
-    }
-    if (retryableSenderFromRec === process.env.SENDER_ADDRESS) {
-      return true
-    } else {
-      return false
     }
   }
 
@@ -266,3 +257,5 @@ export const checkFailedRetryablesLoop = async () => {
   setChainParams()
   await checkFailedRetryables()
 }
+
+


### PR DESCRIPTION
This PR fixes the address comparison issue. The tickets were not being detected because we previously input the sender address in uppercase (as displayed on Etherscan), but the subgraph returned it in lowercase. This inconsistency in letter casing caused the string comparison to fail!